### PR TITLE
fix: prepend bucket name to endpoint for appropriate APIs

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,45 @@
+package s3
+
+import (
+	"testing"
+)
+
+func TestClientBuildEndpoint(t *testing.T) {
+	tests := []struct {
+		name        string
+		endpointURL string
+		bucketName  string
+		path        string
+		want        string
+	}{{
+
+		name:        "with a bucket provided",
+		endpointURL: "https://s3.us-east-1.amazonaws.com",
+		bucketName:  "kickit",
+		want:        "https://kickit.s3.us-east-1.amazonaws.com",
+	}, {
+		name:        "without a bucket provided",
+		endpointURL: "https://s3.us-east-1.amazonaws.com",
+		want:        "https://s3.us-east-1.amazonaws.com",
+	}, {
+		name:        "with a path provided",
+		endpointURL: "https://s3.us-east-1.amazonaws.com",
+		path:        "myobject",
+		want:        "https://s3.us-east-1.amazonaws.com/myobject",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				endpointURL: tt.endpointURL,
+			}
+			got, err := c.buildEndpoint(tt.bucketName, tt.path)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("got: %v, want: %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/example/main.go
+++ b/example/main.go
@@ -21,8 +21,6 @@ func init() {
 		}
 
 		cfg := s3.Config{
-			// Setting config.Endpoint allows us to provide an endpoint other than
-			// AWS. It is not required when using AWS S3.
 			Endpoint: endpoint,
 
 			// The following fields are for your AWS credentials.
@@ -66,7 +64,7 @@ func init() {
 			return
 		}
 
-		fmt.Println("-- Getting object")
+		fmt.Printf("-- Getting object: %q\n", objectName)
 		contents, err := s3Client.GetObject(ctx, bucketName, objectName)
 		if err != nil {
 			fmt.Println(err)

--- a/example/spin.toml
+++ b/example/spin.toml
@@ -13,8 +13,10 @@ component = "spin-s3-example"
 [component.spin-s3-example]
 source = "main.wasm"
 allowed_outbound_hosts = [
+  "http://*.s3.localhost.localstack.cloud:4566",
   "http://s3.localhost.localstack.cloud:4566",
-  "https://s3.us-east-1.amazonaws.com",
+  "https://s3.{{s3_region}}.amazonaws.com",
+  "https://*.s3.{{s3_region}}.amazonaws.com",
 ]
 
 [variables]


### PR DESCRIPTION
Endpoint URL's should be `https://bucketname.s3.region.amazonaws.com` for object actions.